### PR TITLE
UGP-11165 - HOT FIX - Fix large gap between content sections

### DIFF
--- a/blocks/toc/toc.css
+++ b/blocks/toc/toc.css
@@ -5,6 +5,16 @@
     display: block !important;
 }
 
+@media (width >= 900px) {
+    .toc {
+        max-height: calc(100vh - var(--nav-height) - 60px);
+        overflow-y: scroll;
+        border-bottom: 1px solid #eaeaea;
+        padding-left: 12px;
+        padding-right: 12px;
+    }
+}
+
 .toc-content  {
     display: none;
 }
@@ -70,6 +80,12 @@
     width: 100%;
     min-height: 32px;
     padding: 1em 0 2em 8px;
+}
+
+@media (width >= 900px){
+    .toc-header {
+        padding: 0 1em 1em 0;
+    }
 }
 
 
@@ -163,6 +179,7 @@
     position: relative;
     cursor: pointer;
     flex: 12%;
+    padding: 0;
 }
 
 .toc a.toc-toggle::after {

--- a/blocks/toc/toc.css
+++ b/blocks/toc/toc.css
@@ -79,7 +79,7 @@
     box-sizing: border-box;
     width: 100%;
     min-height: 32px;
-    padding: 1em 0 2em 8px;
+    padding: 16px 12px 0;
 }
 
 @media (width >= 900px){
@@ -179,7 +179,7 @@
     position: relative;
     cursor: pointer;
     flex: 12%;
-    padding: 0;
+    padding-right: 12px;
 }
 
 .toc a.toc-toggle::after {

--- a/scripts/rails/rails.css
+++ b/scripts/rails/rails.css
@@ -33,6 +33,10 @@
     left: 0;
     transform: scaleX(-1);
   }
+  .docs main .section.rail.rail-left {
+    padding-left: 12px;
+    padding-right: 0px;
+  }
   .docs main .section.rail.rail-left .rail-toggle {
     right: 0;
   }

--- a/scripts/rails/rails.scss
+++ b/scripts/rails/rails.scss
@@ -43,6 +43,9 @@
     }
 
     &.rail-left {
+      padding-left: 12px;
+      padding-right: 0;
+
       .rail-toggle {
         right: 0;
       }


### PR DESCRIPTION
This PR limits the height of the right-side TOC to the screen height, and overflows the rest (scroll)

This the best way to handle this issue since it's a CSS grid issue. We would otherwise need adjust the HTML (via Js) to get a more appropriate grid.

There's already ongoing work for TOC visibility in: UGP-10847


Jira ID: UGP-11165

Test URLs:

- Before: https://main--exlm--adobe-experience-league.hlx.page/en/docs/integrations-learn/experience-cloud/solution-categories/content-management
- After: https://hotfix-ugp-11165--exlm-prod--adobe-experience-league.hlx.page/en/docs/experience-manager-cloud-service/content/assets/dynamicmedia/dynamic-media-open-apis/deliver-assets-apis
