### PR TITLE
feat: (UGP-14857): add Brand Concierge clear control and update welco…

### DIFF
--- a/scripts/brand-concierge/brand-concierge-config.js
+++ b/scripts/brand-concierge/brand-concierge-config.js
@@ -71,9 +71,9 @@ const brandConciergeConfig = {
 
   arrays: {
     'welcome.examples': [
-      { text: 'Get started with Adobe Experience Manager' },
+      { text: 'Where can I go to learn about AI on Experience League?' },
+      { text: 'Getting started with Experience Manager' },
       { text: 'Set up an Adobe Analytics report suite' },
-      { text: 'Troubleshoot my Adobe Campaign delivery' },
       { text: 'Explain Adobe Target A/B testing' },
     ],
     'feedback.positive.options': [

--- a/scripts/brand-concierge/brand-concierge.css
+++ b/scripts/brand-concierge/brand-concierge.css
@@ -415,58 +415,44 @@
   display: none !important;
 }
 
-/* Expanded only: full-width prompt area; taller, half-width welcome pill cards (not in the narrow drawer). */
-#bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-suggestions-container {
-  max-width: 100% !important;
-}
+/*
+ * Expanded-only prompt layouts (wide viewports). Below 769px, expanded uses the same
+ * full-width prompt stack as the side drawer (base `.bc-prompt-pill-button` rules).
+ */
+@media (min-width: 769px) {
+  /* Expanded only: full-width prompt area; taller, half-width welcome pill cards (not in the narrow drawer). */
+  #bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-suggestions-container {
+    max-width: 100% !important;
+  }
 
-/* Expanded welcome only (four initial pills before chat): keep wrapped row + card-style sizing. */
-#bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-pills-container:has(> :nth-child(4):last-child) {
-  display: flex !important;
-  flex-flow: row wrap !important;
-  justify-content: center !important;
-  gap: 8px !important;
-}
+  /* Expanded welcome only (four initial pills before chat): keep wrapped row + card-style sizing. */
+  #bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-pills-container:has(> :nth-child(4):last-child) {
+    display: flex !important;
+    flex-flow: row wrap !important;
+    justify-content: center !important;
+    gap: 8px !important;
+  }
 
-#bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-suggestions-container .bc-prompt-pill-button,
-#bc-dialog.exl-dialog-expanded
-  #brand-concierge-mount
-  .prompt-pills-container:has(> :nth-child(4):last-child)
-  .bc-prompt-pill-button {
-  --bc-prompt-pill-gap-count: 3;
-  --bc-prompt-pill-gap: 8px;
+  #bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-suggestions-container .bc-prompt-pill-button,
+  #bc-dialog.exl-dialog-expanded
+    #brand-concierge-mount
+    .prompt-pills-container:has(> :nth-child(4):last-child)
+    .bc-prompt-pill-button {
+    --bc-prompt-pill-gap-count: 3;
+    --bc-prompt-pill-gap: 8px;
 
-  flex: 0 1 calc((100% - var(--bc-prompt-pill-gap-count) * var(--bc-prompt-pill-gap)) / 8) !important;
-  width: calc((100% - var(--bc-prompt-pill-gap-count) * var(--bc-prompt-pill-gap)) / 8) !important;
-  max-width: calc((100% - var(--bc-prompt-pill-gap-count) * var(--bc-prompt-pill-gap)) / 8) !important;
-  box-sizing: border-box !important;
-  min-height: calc((16px + 1.4 * 13px) * 3) !important;
-  padding: 24px 12px !important;
-  align-items: flex-start !important;
-  justify-content: center !important;
-}
+    flex: 0 1 calc((100% - var(--bc-prompt-pill-gap-count) * var(--bc-prompt-pill-gap)) / 8) !important;
+    width: calc((100% - var(--bc-prompt-pill-gap-count) * var(--bc-prompt-pill-gap)) / 8) !important;
+    max-width: calc((100% - var(--bc-prompt-pill-gap-count) * var(--bc-prompt-pill-gap)) / 8) !important;
+    min-width: 130px !important;
+    box-sizing: border-box !important;
+    min-height: calc((16px + 1.4 * 13px) * 3) !important;
+    padding: 24px 12px !important;
+    align-items: flex-start !important;
+    justify-content: center !important;
+  }
 
-/* Expanded in-chat follow-up suggestions: full-width pills, vertical stack (not the initial welcome row). */
-#bc-dialog.exl-dialog-expanded
-  #brand-concierge-mount
-  .chat-history
-  .prompt-suggestions-container:has(.bc-prompt-suggestion-button),
-#bc-dialog.exl-dialog-expanded
-  #brand-concierge-mount
-  .chat-history
-  .prompt-suggestions-container:has(.bc-prompt-suggestion-button)
-  .prompt-pills-container {
-  display: flex !important;
-  flex-flow: column nowrap !important;
-  align-items: stretch !important;
-  justify-content: flex-start !important;
-  gap: 8px !important;
-  width: auto !important;
-  min-width: 60% !important;
-  max-width: 70% !important;
-}
-
-@media (max-width: 767px) {
+  /* Expanded in-chat follow-up suggestions: full-width pills, vertical stack (not the initial welcome row). */
   #bc-dialog.exl-dialog-expanded
     #brand-concierge-mount
     .chat-history
@@ -476,23 +462,40 @@
     .chat-history
     .prompt-suggestions-container:has(.bc-prompt-suggestion-button)
     .prompt-pills-container {
+    display: flex !important;
+    flex-flow: column nowrap !important;
+    align-items: stretch !important;
+    justify-content: flex-start !important;
+    gap: 8px !important;
+    width: auto !important;
     max-width: 100% !important;
+  }
+
+  #bc-dialog.exl-dialog-expanded
+    #brand-concierge-mount
+    .chat-history
+    .prompt-suggestions-container
+    .bc-prompt-suggestion-button {
+    flex: none !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    min-height: 0 !important;
+    padding: 8px 12px !important;
+    align-items: center !important;
+    justify-content: flex-start !important;
+    box-sizing: border-box !important;
   }
 }
 
-#bc-dialog.exl-dialog-expanded
-  #brand-concierge-mount
-  .chat-history
-  .prompt-suggestions-container
-  .bc-prompt-suggestion-button {
-  flex: none !important;
-  width: 100% !important;
-  max-width: 100% !important;
-  min-height: 0 !important;
-  padding: 8px 12px !important;
-  align-items: center !important;
-  justify-content: flex-start !important;
-  box-sizing: border-box !important;
+/* Expanded on narrow viewports: match side-drawer prompt stack (full-width pills, same gap as base). */
+@media (max-width: 768px) {
+  #bc-dialog.exl-dialog-expanded #brand-concierge-mount .prompt-pills-container:has(> :nth-child(4):last-child) {
+    display: flex !important;
+    flex-flow: column nowrap !important;
+    align-items: stretch !important;
+    justify-content: flex-start !important;
+    gap: 6px !important;
+  }
 }
 
 #brand-concierge-mount .submit-button {

--- a/scripts/brand-concierge/brand-concierge.js
+++ b/scripts/brand-concierge/brand-concierge.js
@@ -9,7 +9,12 @@ const ALLOY_INSTANCE_NAME = 'alloyBC';
 const MOUNT_SELECTOR = '#brand-concierge-mount';
 const DIALOG_ID = 'bc-dialog';
 const TRIGGER_ID = 'bc-trigger';
+const HEADER_CLEAR_ID = 'bc-header-clear';
 const PANEL_DISCLAIMER_ID = 'bc-panel-disclaimer';
+
+/** Brand Concierge web client transcript keys (see ChatTranscriptStorage in bc main.js). */
+const BC_STORAGE_TRANSCRIPT_PREFIX = 'bc_chat_transcript_';
+const BC_STORAGE_METADATA_KEY = 'bc_chat_metadata';
 
 const PRIVACY_POLICY_URL = 'https://www.adobe.com/privacy/policy.html';
 const GENERATIVE_AI_TERMS_URL = 'https://www.adobe.com/legal/licenses-terms/adobe-gen-ai-user-guidelines.html';
@@ -27,6 +32,37 @@ let drawerHandle = null;
 let chatObserver = null;
 let inputLabelIconObserver = null;
 let panelDisclaimerObserver = null;
+
+/**
+ * Removes persisted BC chat sessions from localStorage (transcript + metadata).
+ * @param {{ broad?: boolean }} [options] - If broad, also remove any key containing `bc_chat`.
+ */
+function clearBrandConciergeTranscriptStorage(options = {}) {
+  const { broad = false } = options;
+  const toRemove = [];
+  for (let i = 0; i < localStorage.length; i += 1) {
+    const key = localStorage.key(i);
+    if (
+      key &&
+      (key === BC_STORAGE_METADATA_KEY ||
+        key.startsWith(BC_STORAGE_TRANSCRIPT_PREFIX) ||
+        (broad && key.includes('bc_chat')))
+    ) {
+      toRemove.push(key);
+    }
+  }
+  toRemove.forEach((k) => localStorage.removeItem(k));
+}
+
+function getBootstrapOptions() {
+  const { stickySession = false, ...stylingConfigurations } = brandConciergeConfig;
+  return {
+    instanceName: ALLOY_INSTANCE_NAME,
+    stylingConfigurations,
+    selector: MOUNT_SELECTOR,
+    stickySession,
+  };
+}
 
 /**
  * BC renders inline SVG sparkles in several places; swap them for icons/bc-ask-sparkles.svg.
@@ -150,6 +186,60 @@ function focusBcChatInputWhenReady(mount) {
   timeoutId = window.setTimeout(cleanup, 8000);
 }
 
+// scroll the container to the bottom each time.
+function watchChatHistory(mount) {
+  const history = mount.querySelector('.chat-history');
+  if (!history) return null;
+
+  const observer = new MutationObserver(() => {
+    history.scrollTo({ top: history.scrollHeight, behavior: 'smooth' });
+  });
+
+  observer.observe(history, { childList: true });
+  return observer;
+}
+
+/**
+ * Resets the assistant to the first-use welcome state: clears transcript storage and re-runs bootstrap.
+ * The BC client calls reinitialize() when bootstrap is invoked again after the first load.
+ */
+async function clearBrandConciergeConversation() {
+  const concierge = window.adobe?.concierge;
+  if (typeof concierge?.bootstrap !== 'function') {
+    warn('Clear: concierge bootstrap not available');
+    return;
+  }
+
+  try {
+    if (typeof concierge.clearAllSessions === 'function') {
+      concierge.clearAllSessions();
+    } else if (typeof concierge.clearHistory === 'function') {
+      concierge.clearHistory();
+    }
+  } catch (e) {
+    warn('Clear: optional concierge clear API failed (continuing)', e?.message || e);
+  }
+
+  clearBrandConciergeTranscriptStorage({ broad: false });
+
+  try {
+    await concierge.bootstrap(getBootstrapOptions());
+  } catch (e) {
+    warn('Clear: first re-bootstrap failed; retrying after broader storage cleanup', e?.message || e);
+    clearBrandConciergeTranscriptStorage({ broad: true });
+    await concierge.bootstrap(getBootstrapOptions());
+  }
+
+  const bcMount = document.getElementById('brand-concierge-mount');
+  chatObserver?.disconnect();
+  chatObserver = watchChatHistory(bcMount);
+  patchBcSparkleIcons(bcMount);
+  panelDisclaimerObserver?.disconnect();
+  panelDisclaimerObserver = null;
+  watchPanelDisclaimer(bcMount);
+  focusBcChatInputWhenReady(bcMount);
+}
+
 function createMountPoint() {
   if (document.getElementById(DIALOG_ID)) return document.getElementById(DIALOG_ID);
 
@@ -179,6 +269,13 @@ function createMountPoint() {
   const mount = document.createElement('div');
   mount.id = 'brand-concierge-mount';
 
+  const clearBtn = document.createElement('button');
+  clearBtn.id = HEADER_CLEAR_ID;
+  clearBtn.type = 'button';
+  clearBtn.className = 'exl-dialog-header-clear';
+  clearBtn.textContent = 'Clear';
+  clearBtn.setAttribute('aria-label', 'Clear conversation');
+
   drawerHandle = openDrawer({
     id: DIALOG_ID,
     ariaLabel: 'AI assistant',
@@ -187,6 +284,7 @@ function createMountPoint() {
     titleIcon: 'bc-ask-sparkles',
     content: mount,
     canExpand: true,
+    beforeExpandButton: clearBtn,
     triggerEl: trigger,
     onClose: () => trigger.setAttribute('aria-expanded', 'false'),
   });
@@ -203,20 +301,11 @@ function createMountPoint() {
     focusBcChatInputWhenReady(mount);
   });
 
-  return dialog;
-}
-
-// scroll the container to the bottom each time.
-function watchChatHistory(mount) {
-  const history = mount.querySelector('.chat-history');
-  if (!history) return null;
-
-  const observer = new MutationObserver(() => {
-    history.scrollTo({ top: history.scrollHeight, behavior: 'smooth' });
+  clearBtn.addEventListener('click', () => {
+    clearBrandConciergeConversation().catch((e) => warn('Clear conversation failed', e?.message || e));
   });
 
-  observer.observe(history, { childList: true });
-  return observer;
+  return dialog;
 }
 
 async function configureWebSdk(bcDatastreamId, bcOrgId, bcEdgeDomain) {
@@ -239,16 +328,9 @@ function bootstrapWebClient() {
     return;
   }
 
-  const { stickySession = false, ...stylingConfigurations } = brandConciergeConfig;
-
   log('bootstrap called', { instanceName: ALLOY_INSTANCE_NAME, selector: MOUNT_SELECTOR });
 
-  window.adobe.concierge.bootstrap({
-    instanceName: ALLOY_INSTANCE_NAME,
-    stylingConfigurations,
-    selector: MOUNT_SELECTOR,
-    stickySession,
-  });
+  window.adobe.concierge.bootstrap(getBootstrapOptions());
 }
 
 /**

--- a/scripts/dialog/dialog.css
+++ b/scripts/dialog/dialog.css
@@ -30,11 +30,15 @@ dialog[data-type] {
   flex-shrink: 0;
 }
 
-.exl-dialog-header-title {
+/* Match ExL heading scale (.h3): bold, stands out; compact line-height for the 48px header bar */
+.exl-dialog-header .exl-dialog-header-title {
   flex: 1;
+  margin: 0;
   font-family: var(--body-font-family);
-  font-size: 20px;
-  font-weight: 600;
+  font-size: var(--exlm-font-size-h3);
+  font-weight: var(--font-weight-bold);
+  font-style: normal;
+  line-height: 1.2;
   color: var(--spectrum-gray-800);
 }
 
@@ -63,7 +67,8 @@ dialog[data-type] {
 }
 
 .exl-dialog-header-expand,
-.exl-dialog-header-close {
+.exl-dialog-header-close,
+.exl-dialog-header-clear {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -80,12 +85,47 @@ dialog[data-type] {
   transition: background-color 0.15s ease;
 }
 
+/* Text control (e.g. Clear) — secondary outline button, distinct from icon-only controls */
+.exl-dialog-header-clear {
+  width: auto;
+  min-width: auto;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid var(--spectrum-gray-300);
+  background: var(--spectrum-gray-50);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 6%);
+  font-family: var(--body-font-family);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--spectrum-gray-800);
+}
+
+.exl-dialog-header-clear:hover {
+  background: var(--spectrum-gray-100);
+  border-color: var(--spectrum-gray-400);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
+}
+
+.exl-dialog-header-clear:active {
+  background: var(--spectrum-gray-200);
+  border-color: var(--spectrum-gray-500);
+  box-shadow: none;
+}
+
 /* styles.css declares `button:focus { background-color: var(--link-hover-color) }` without
  * a :focus-visible guard, which bleeds the brand blue onto these buttons on programmatic
  * focus (e.g. showModal()). Reset here, then restore the outline for keyboard-only. */
 .exl-dialog-header-expand:focus,
 .exl-dialog-header-close:focus {
   background: none;
+  outline: none;
+}
+
+.exl-dialog-header-clear:focus {
+  background: var(--spectrum-gray-50);
+  border-color: var(--spectrum-gray-300);
   outline: none;
 }
 
@@ -110,7 +150,8 @@ dialog[data-type] {
 }
 
 .exl-dialog-header-expand:focus-visible,
-.exl-dialog-header-close:focus-visible {
+.exl-dialog-header-close:focus-visible,
+.exl-dialog-header-clear:focus-visible {
   outline: 2px solid var(--non-spectrum-navy-blue);
   outline-offset: 2px;
 }

--- a/scripts/dialog/dialog.js
+++ b/scripts/dialog/dialog.js
@@ -8,7 +8,7 @@ async function ensureStyles() {
   return document.querySelector(`head > link[href="${DIALOG_CSS}"]`);
 }
 
-function buildDefaultHeader({ title, titleIcon, titleBadge, canExpand }, dialog) {
+function buildDefaultHeader({ title, titleIcon, titleBadge, canExpand, beforeExpandButton }, dialog) {
   const header = document.createElement('div');
   header.className = 'exl-dialog-header';
 
@@ -19,7 +19,7 @@ function buildDefaultHeader({ title, titleIcon, titleBadge, canExpand }, dialog)
     header.append(icon);
   }
 
-  const titleEl = document.createElement('span');
+  const titleEl = document.createElement('h2');
   titleEl.className = 'exl-dialog-header-title';
   if (titleBadge) {
     titleEl.classList.add('exl-dialog-header-title-with-badge');
@@ -32,6 +32,10 @@ function buildDefaultHeader({ title, titleIcon, titleBadge, canExpand }, dialog)
     titleEl.textContent = title || '';
   }
   header.append(titleEl);
+
+  if (beforeExpandButton) {
+    header.append(beforeExpandButton);
+  }
 
   let setExpanded = () => {};
 
@@ -91,6 +95,7 @@ function buildDefaultHeader({ title, titleIcon, titleBadge, canExpand }, dialog)
  * @param {string}       [options.titleBadge]    - Optional pill label after the title (e.g. BETA).
  * @param {string}       [options.titleIcon]     - Default header icon class suffix.
  * @param {boolean}      [options.canExpand]     - Drawer only: show expand/collapse toggle.
+ * @param {HTMLElement}  [options.beforeExpandButton] - Drawer only: inserted left of expand (before expand when canExpand).
  * @param {HTMLElement}  [options.header]        - Custom header; replaces the default.
  * @param {string}       [options.closeSelector] - Selector for the close trigger inside a custom header.
  * @param {HTMLElement}  [options.content]       - Scrollable body content.
@@ -107,6 +112,7 @@ function createDialog(type, options) {
     titleBadge,
     titleIcon,
     canExpand,
+    beforeExpandButton,
     header: customHeader,
     closeSelector,
     content,
@@ -139,6 +145,7 @@ function createDialog(type, options) {
         titleBadge,
         titleIcon,
         canExpand: type === 'drawer' && canExpand,
+        beforeExpandButton: type === 'drawer' && canExpand ? beforeExpandButton : undefined,
       },
       dialog,
     );


### PR DESCRIPTION
…me prompts (#2599)

- Add Clear header button left of expand with outline styling; drawer supports optional beforeExpandButton
- Reset chat by clearing BC transcript localStorage and re-running concierge bootstrap; share bootstrap options via getBootstrapOptions
- Replace welcome example prompts with four new story strings; use semantic h2 title with ExL h3-scale typography
- Expanded mode: min 130px welcome pills from 769px up; below 769px match drawer prompt stack

Please provide the Jira Issue your PR is for.

<!-- Please also provide test paths following the template below. -->

Jira ID:

<!--
    NOTE: when you raise this PR, `$` will be automatically replaced with your brnach url to test agains.
    this is done via the github action located at `/.github/workflows/update-pr-description.yaml`

    Use the list below as a guide, keep the paths you need, remove ones you dont, or add your own.
    Just be sure to follow the pattern of prefixing your paths with `$`
-->

Test URLs:

- Before: https://main--exlm--adobe-experience-league.aem.live

- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/browse?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/browse/analytics?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/docs?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/docs/analytics?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/docs/analytics/analyze/admin-overview/analytics-overview?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/events?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/playlists?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/playlists/acrobat-sign-perform-advanced-tasks-administrators?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/perspectives?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/perspectives/drive-success-with-executive-summary-dashboards?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/certification-home?martech=off
- After: https://hotfix-UGP-14857--exlm-prod--adobe-experience-league.aem.live/en/search?martech=off